### PR TITLE
removes requirement for region to be specified

### DIFF
--- a/aws.html
+++ b/aws.html
@@ -48,7 +48,7 @@
         defaults: {
             aws: {type:"minio-config",required:true},
             bucket: {required:true},
-            region: {value:"", required:true},
+            region: {value:""},
             contentType: {value:""},
             filepattern: {value:""},
             name: {value:""},


### PR DESCRIPTION
The region is not required when using Minio, and the code defaults to eu-west-1.